### PR TITLE
Fix playerList CSS selector

### DIFF
--- a/content/information-aggregation/skill-table.js
+++ b/content/information-aggregation/skill-table.js
@@ -1438,7 +1438,7 @@ Foxtrick.modules.SkillTable = {
 					insertParent.appendChild(tableDiv);
 				}
 				else {
-					var playerList = doc.querySelector('.playerList');
+					var playerList = doc.querySelector('#mainBody > .playerList');
 					if (playerList) {
 						// If there is playerList, as there is in youth/senior teams,
 						// insert before it. In such cases, there would be category headers

--- a/content/information-aggregation/youth-skills.js
+++ b/content/information-aggregation/youth-skills.js
@@ -673,7 +673,7 @@ Foxtrick.modules['YouthSkills'] = {
 				Foxtrick.modules['TeamStats'].execute(doc);
 		};
 
-		entry = doc.querySelector('.playerList');
+		entry = doc.querySelector('#mainBody > .playerList');
 		if (entry)
 			drawMessage(doc);
 

--- a/content/pages/players.js
+++ b/content/pages/players.js
@@ -185,7 +185,7 @@ Foxtrick.Pages.Players.getPlayerNodes = function(doc, include) {
 	};
 
 	let mainBody = doc.getElementById('mainBody');
-	let playerList = doc.querySelector('.playerList');
+	let playerList = doc.querySelector('#mainBody > .playerList');
 	let nodeColl = playerList ? playerList.children : mainBody.children;
 
 	let nodes = /** @type {HTMLElement[]} */ ([...nodeColl]);

--- a/content/shortcuts-and-tweaks/player-filters.js
+++ b/content/shortcuts-and-tweaks/player-filters.js
@@ -420,7 +420,7 @@ Foxtrick.modules['PlayerFilters'] = {
 			};
 
 			var body = doc.getElementById('mainBody');
-			var pList = doc.querySelector('.playerList');
+			var pList = doc.querySelector('#mainBody > .playerList');
 			if (!pList) {
 				// presumably fog of war in NT
 				return;


### PR DESCRIPTION
Hattrick's own player table now uses the 'playerList' class on some of its elements, so we need a more specific selector to get the regular list of players.

<!-- Please review the contributing guidelines before submitting this PR. -->
