### PR TITLE
Fix PsicoTSI wage calculation for players with specialty

### DIFF
--- a/content/information-aggregation/psico-tsi.js
+++ b/content/information-aggregation/psico-tsi.js
@@ -105,8 +105,8 @@ Foxtrick.modules['PsicoTSI'] = {
 			return;
 
 		p.tsi = Foxtrick.Pages.Player.getTsi(doc);
-		let wo = Foxtrick.Pages.Player.getWage(doc);
-		p.salary = wo && wo.base;
+		p.salary = Foxtrick.Pages.Player.getWage(doc).base;
+		p.specialtyNumber = Foxtrick.Pages.Player.getSpecialtyNumber(doc);
 		p.isAbroad = false;
 
 		var attrs = Foxtrick.Pages.Player.getAttributes(doc);
@@ -217,7 +217,10 @@ Foxtrick.modules['PsicoTSI'] = {
 		let age = p.ageYears || p.age.years;
 		let currTSI = p.tsi;
 		let currWAGE = currRate ? Math.floor(p.salary / (p.isAbroad ? 1.2 : 1) * currRate) : 0;
-
+		if (p.specialtyNumber) {
+			// players with a speciality have a 10% higher salary
+			currWAGE = currWAGE * (10 / 11);
+		}
 		let frm = p.form;
 		let sta = p.stamina;
 

--- a/content/pages/player.js
+++ b/content/pages/player.js
@@ -539,13 +539,10 @@ Foxtrick.Pages.Player.getSpecialtyNumber = function(doc) {
 		var playerNode = doc.querySelector('.playerInfo');
 		var isNewDesign = !!playerNode.querySelector('.transferPlayerInformation');
 
-		/** @type {HTMLTableElement} */
-		var playerInfo = playerNode.querySelector('table');
-
 		if (isNewDesign) {
 			const SPEC_PREFIX = 'icon-speciality-'; // HT-TYPO
 			const SPEC_SUFFIX = 'trSpeciality'; // HT-TYPO
-			let specTd = playerInfo.querySelector(`tr[id$="${SPEC_SUFFIX}"] td:nth-child(2)`);
+			let specTd = playerNode.querySelector(`.transferPlayerInformation table tr[id$="${SPEC_SUFFIX}"] td:nth-child(2)`);
 			let specIcon;
 			if (specTd && (specIcon = specTd.querySelector(`i[class*="${SPEC_PREFIX}"]`))) {
 				let classes = [...specIcon.classList];
@@ -554,6 +551,8 @@ Foxtrick.Pages.Player.getSpecialtyNumber = function(doc) {
 			}
 		}
 		else {
+			/** @type {HTMLTableElement} */
+			let playerInfo = playerNode.querySelector('table');
 			let specRow = playerInfo.rows[5];
 			if (specRow) {
 				let specText = specRow.cells[1].textContent.trim();


### PR DESCRIPTION
<!-- Please review the contributing guidelines before submitting this PR. -->
Fix from user Ben-Zahler:
"Two years ago, an update in HT was implemented with which players that have a specialty have a 10% higher salary.
This is not reflected in PsicoTSI from what I see."