### PR TITLE
fix userName detection from breadcrumbs on Manager page

### DIFF
--- a/content/links/links-manager.js
+++ b/content/links/links-manager.js
@@ -26,7 +26,8 @@ Foxtrick.modules['LinksManager'] = {
 	links: function(doc) {
 		var userId = Foxtrick.Pages.All.getId(doc);
 		var bcs = Foxtrick.Pages.All.getBreadCrumbs(doc);
-		var userName = bcs[1].textContent;
+		// if bcs is length 1 - no team name in breadcrumbs - we are on the user's own manager page 
+		var userName = bcs[ bcs.length == 1 ? 0 : 1 ].textContent;
 
 		var info = {
 			userId: userId,


### PR DESCRIPTION
Depending upon which Manager link/url is followed by the user when viewing their own Manager page, the team name may or may not be displayed in the breadcrumbs.

<!-- Please review the contributing guidelines before submitting this PR. -->
