### PR TITLE
fix copyPlayerAd on classic pages

### DIFF
--- a/content/pages/player.js
+++ b/content/pages/player.js
@@ -617,7 +617,7 @@ Foxtrick.Pages.Player.getSkillsWithText = function(doc) {
 			/** @type {HTMLTableElement} */
 			var skillTable;
 			if (this.isSenior(doc)) {
-				skillTable = doc.querySelector('.transferPlayerSkills, .mainBox table');
+				skillTable = doc.querySelector('.transferPlayerSkills, .mainBox:not(.ft-dummy) table');
 				return this.parseSeniorSkills(skillTable);
 			}
 


### PR DESCRIPTION
In classic pages, once the page was fully rendered, subsequent calls to Player.getSkillsWithText would select the PsicoTSI table instead of the player skills table.  A modified CSS selector fixes this.

This bug caused the Copy Player Ad function to not include the player's skills.

<!-- Please review the contributing guidelines before submitting this PR. -->
