### PR TITLE
Enhance Hattrick Portal links

### DIFF
--- a/res/links.json
+++ b/res/links.json
@@ -414,6 +414,10 @@
 	"hattrickportal": {
 		"title": "Hattrick Portal NT/U20 tracker",
 		"img": "https://www.foxtrick.org/res/linkicons/hattrickportal.ico",
+		"playerslink": {
+			"url": "https://hattrickportal.pro/Tracker",
+			"filters": ["ownteamid"]
+		},
 		"trackerleaguelink": {
 			"url": "https://hattrickportal.pro/Tracker"
 		},
@@ -421,7 +425,7 @@
 			"url": "https://hattrickportal.pro/Tracker"
 		},
 		"trackerplayerlink": {
-			"url": "https://hattrickportal.pro/Tracker"
+			"url": "https://hattrickportal.pro/Tracker/Player.aspx?playerID=[playerid]"
 		}
 	},
 	"hattrick-youthclub": {


### PR DESCRIPTION
- Updated link from player page to point to that player page in Portal (this works even if the user does not own the player)
- Added link to Hattrick's `Players` page (only for the current user team) to Portal's `Your players` page

Please note that:
1) I haven't tested the changes because I'm not sure how to do so. In particular, `playerslink` does not yet appear in this file (but is referenced in links-players.js), and the `ownteamid` has very limited examples in this file,
2) I'm not affiliated in any way to Hattrick Portal and there's AFAIK no ask from their side to do such a change.