### PR TITLE
fix LiveAlert on new Live view

### DIFF
--- a/content/alert/live-alert.js
+++ b/content/alert/live-alert.js
@@ -208,6 +208,7 @@ Foxtrick.modules['LiveAlert'] = {
 
 			Foxtrick.util.notify.create(txt, url, { id: info.teamsText })
 				.catch(e => e.message != Foxtrick.TIMEOUT_ERROR ? Promise.reject(e) : e)
+				// @ts-ignore: MODULE_NAME is set after module is loaded
 				.catch(Foxtrick.catch(MODULE));
 		}
 

--- a/content/alert/live-alert.js
+++ b/content/alert/live-alert.js
@@ -20,7 +20,7 @@ Foxtrick.modules['LiveAlert'] = {
 	run: function(doc) {
 		let isNewLive = Foxtrick.Pages.Match.isNewLive(doc);
 		let results = isNewLive ?
-			doc.querySelector('#ngLive .htbox-content') :
+			doc.querySelector('#ngLive .ht-tabs') :
 			Foxtrick.getMBElement(doc, 'UpdatePanelPopupMessages');
 
 		if (!results)
@@ -32,10 +32,18 @@ Foxtrick.modules['LiveAlert'] = {
 		if (!isNewLive)
 			return;
 
+		// call runTabs after page load to set initial stored values for scores
+		this.runTabs(doc, results);
+
+		/*
+		 * The score tabs in the Live scores banner now update immediately,
+		 * so we no longer need this. 
+		 *
 		// add overlay pre-announce support
 		let container = doc.querySelector('.live-left-container');
 		if (container)
 			Foxtrick.onChange(container, this.runOverlay.bind(this));
+		*/
 	},
 
 	// onChange: function(doc) {
@@ -118,7 +126,7 @@ Foxtrick.modules['LiveAlert'] = {
 		var ret = null;
 
 		if (Foxtrick.Pages.Match.isNewLive(tab.ownerDocument))
-			ret = Foxtrick.toArray(tab.querySelectorAll('.ellipsis'));
+			ret = Foxtrick.toArray(tab.querySelectorAll('span.ellipsis'));
 		else
 			ret = [tab.querySelector('.hometeam'), tab.querySelector('.awayteam')];
 

--- a/content/alert/live-alert.js
+++ b/content/alert/live-alert.js
@@ -87,8 +87,8 @@ Foxtrick.modules['LiveAlert'] = {
 	 * Get goals from tab.
 	 *
 	 * Returns [home, away] goals as integers
-	 * @param  {Element} tab
-	 * @return {array}       <Array.<number>>
+	 * @param  {Element} tab Element containing team names and score
+	 * @return {Array}       <Array.<number>>
 	 */
 	getScoreFromTab: function(tab) {
 		if (!tab)
@@ -119,8 +119,8 @@ Foxtrick.modules['LiveAlert'] = {
 	 *
 	 * Returns an [home, away] where teams are either links or spans.
 	 * team.title = full team name team.textContent = shortTeamName.
-	 * @param  {Element} tab
-	 * @return {array}       {Array.<HTMLAnchorElement|HTMLSpanElement}
+	 * @param  {Element} tab Element containing team names and score
+	 * @return {Array}       {Array.<HTMLAnchorElement|HTMLSpanElement}
 	 */
 	getTeamsFromTab: function(tab) {
 		var ret = null;


### PR DESCRIPTION
fix LiveAlert for updated Live view
- updated css selectors for Live score banner and score tabs
- disabled redundant runOverlay
- call runTabs at init to set stored score values
