### PR TITLE
fix NT matches not appearing in MyMonitor

### DIFF
--- a/content/information-aggregation/my-monitor.js
+++ b/content/information-aggregation/my-monitor.js
@@ -145,8 +145,7 @@ Foxtrick.modules.MyMonitor = {
 			 * @type {MyMonitorFilterType[]}
 			 */
 			var matchesByType = [
-			//	README: disabled as this does the same thing as source: Senior in current implementation
-			//	'Official',
+				'Official',
 			//	README: diabled as NT matches are now source: HTOIntegrated
 			//	'NT',
 			];

--- a/content/information-aggregation/my-monitor.js
+++ b/content/information-aggregation/my-monitor.js
@@ -130,9 +130,8 @@ Foxtrick.modules.MyMonitor = {
 			var matchesBySource = [
 				{ source: 'Hattrick', type: 'senior' },
 				{ source: 'Youth', type: 'youth' },
-
-				// README: HTO matches currently disabled in my monitor
-				// { source: 'HTOIntegrated', type: 'hto' },
+				// README: NT matches are now source: HTOIntegrated
+				{ source: 'HTOIntegrated', type: 'nt' },
 			];
 
 			Foxtrick.forEach(function(t) {
@@ -146,8 +145,10 @@ Foxtrick.modules.MyMonitor = {
 			 * @type {MyMonitorFilterType[]}
 			 */
 			var matchesByType = [
-				'Official',
-				'NT',
+			//	README: disabled as this does the same thing as source: Senior in current implementation
+			//	'Official',
+			//	README: diabled as NT matches are now source: HTOIntegrated
+			//	'NT',
 			];
 
 			Foxtrick.forEach(function(t) {
@@ -189,7 +190,7 @@ Foxtrick.modules.MyMonitor = {
 				var url;
 
 				if (source) {
-					var re = new RegExp(Foxtrick.strToRe(source), 'i');
+					var re = new RegExp(Foxtrick.strToRe(source));
 					var sourceMatches = Foxtrick.filter(function(link) {
 						return re.test(link.href);
 					}, liveLinks);

--- a/content/information-aggregation/my-monitor.js
+++ b/content/information-aggregation/my-monitor.js
@@ -146,7 +146,7 @@ Foxtrick.modules.MyMonitor = {
 			 */
 			var matchesByType = [
 				'Official',
-			//	README: diabled as NT matches are now source: HTOIntegrated
+			//	README: disabled as NT matches are now source: HTOIntegrated
 			//	'NT',
 			];
 

--- a/content/information-aggregation/my-monitor.js
+++ b/content/information-aggregation/my-monitor.js
@@ -36,8 +36,8 @@ Foxtrick.modules.MyMonitor = {
 			var teams = [];
 			try {
 				teams = JSON.parse(savedTeams);
-			}
-			catch (e) {
+			} 
+			catch {
 				Foxtrick.log('Cannot parse saved teams:', savedTeams);
 			}
 
@@ -167,8 +167,7 @@ Foxtrick.modules.MyMonitor = {
 			var infoCell = row.appendChild(doc.createElement('td'));
 			infoCell.id = 'ft-monitor-live-info';
 
-			Foxtrick.onClick(button, function(ev) {
-				// eslint-disable-next-line no-invalid-this
+			Foxtrick.onClick(button, function() { 
 				var doc = this.ownerDocument;
 
 				/** @type {NodeListOf<HTMLAnchorElement>} */
@@ -243,6 +242,7 @@ Foxtrick.modules.MyMonitor = {
 
 		/**
 		 * display my monitor on MyHT, a.k.a news, and dashboard page
+		 * 
 		 * @param {document} doc
 		 */
 		var display = function(doc) {
@@ -282,7 +282,6 @@ Foxtrick.modules.MyMonitor = {
 			var sortAndReload = function(order) {
 				return function() {
 					Foxtrick.Prefs.setModuleValue('MyMonitor', order);
-					// eslint-disable-next-line no-invalid-this
 					this.ownerDocument.location.reload();
 				};
 			};
@@ -463,10 +462,9 @@ Foxtrick.modules.MyMonitor = {
 				 * @return {Listener<HTMLInputElement, MouseEvent>}
 				 */
 				var move = function(direction) {
-					return function(ev) {
+					return function() {
 						var teams = getSavedTeams();
 						var frames = [...doc.getElementsByClassName('ft-monitor-frame')];
-						// eslint-disable-next-line no-invalid-this, consistent-this
 						var thisFrame = this;
 						thisFrame = thisFrame.closest('.ft-monitor-frame');
 						if (!thisFrame) {
@@ -587,9 +585,9 @@ Foxtrick.modules.MyMonitor = {
 
 		/**
 		 * show my monitor shortcuts in sidebar
+		 * 
 		 * @param {document} doc
 		 */
-		// eslint-disable-next-line complexity
 		var showSidebar = function(doc) {
 			/** @type {MyMonitorTeamType} */
 			var type;

--- a/content/util/match-view.js
+++ b/content/util/match-view.js
@@ -76,13 +76,10 @@ Foxtrick.util.matchView.fillMatches = function(container, xml, errorText) {
 		return type2info(type, cup);
 	};
 
-	/**
-	 * Detects if the Team is a NT/U21 team.
-	 * @return {boolean} is NT/U21
-	 */
-	const isNt = function() {
-		return xml.text('ShortTeamName') == '';
-	}
+	/* FIXME: Only NTs have an empty ShortTeamName.
+	This is obviously a hack. Best fixed by refactoring this module to use
+	nationalteammatches.xml for NT matches. */
+	let isNt = xml.text('ShortTeamName') == '';
 
 	/**
 	 * Map HTO match type to NT match types
@@ -91,7 +88,7 @@ Foxtrick.util.matchView.fillMatches = function(container, xml, errorText) {
 	 */
 	const mapNtType = function(type) {
 		let ntTypeMap = { 50: 10, 51: 11, 61: 12 };
-		return isNt() ? ntTypeMap[type] : type;
+		return isNt ? ntTypeMap[type] : type;
 	}
 
 	var doc = container.ownerDocument;
@@ -142,7 +139,7 @@ Foxtrick.util.matchView.fillMatches = function(container, xml, errorText) {
 		matchLink.dataset.matchType = match.type;
 		
 		let sourceSystem = 'Hattrick';
-		if (isNt())
+		if (isNt)
 			sourceSystem = 'HTOIntegrated';
 		else if (isYouth)
 			sourceSystem = 'Youth';

--- a/content/util/match-view.js
+++ b/content/util/match-view.js
@@ -69,12 +69,30 @@ Foxtrick.util.matchView.fillMatches = function(container, xml, errorText) {
 		return null;
 	};
 	var getMatchInfo = function(match) {
-		var type = xml.text('MatchType', match);
+		var type = mapNtType(xml.text('MatchType', match));
 		var cupLvl = xml.num('CupLevel', match);
 		var cupIdx = xml.num('CupLevelIndex', match);
 		var cup = cupLvl * 3 + cupIdx;
 		return type2info(type, cup);
 	};
+
+	/**
+	 * Detects if the Team is a NT/U21 team.
+	 * @return {boolean} is NT/U21
+	 */
+	const isNt = function() {
+		return xml.text('ShortTeamName') == '';
+	}
+
+	/**
+	 * Map HTO match type to NT match types
+	 * @param {number} type match type 
+	 * @return {number} match type
+	 */
+	const mapNtType = function(type) {
+		let ntTypeMap = { 50: 10, 51: 11, 61: 12 };
+		return isNt() ? ntTypeMap[type] : type;
+	}
 
 	var doc = container.ownerDocument;
 	var IS_RTL = Foxtrick.util.layout.isRtl(doc);
@@ -122,8 +140,14 @@ Foxtrick.util.matchView.fillMatches = function(container, xml, errorText) {
 		var matchCell = doc.createElement('td');
 		var matchLink = doc.createElement('a');
 		matchLink.dataset.matchType = match.type;
-		matchLink.href = '/Club/Matches/Match.aspx?matchID=' + match.id + '&SourceSystem=' +
-			(isYouth ? 'Youth' : 'Hattrick');
+		
+		let sourceSystem = 'Hattrick';
+		if (isNt())
+			sourceSystem = 'HTOIntegrated';
+		else if (isYouth)
+			sourceSystem = 'Youth';
+		
+		matchLink.href = '/Club/Matches/Match.aspx?matchID=' + match.id + '&SourceSystem=' + sourceSystem;
 
 		// limit team name length to fit in one line
 		var cutLength = 12;
@@ -171,7 +195,7 @@ Foxtrick.util.matchView.fillMatches = function(container, xml, errorText) {
 			// add HT-Live
 			var liveLink = doc.createElement('a');
 			liveLink.href = '/Club/Matches/Live.aspx?actionType=addMatch&matchID=' + match.id +
-				'&SourceSystem=' + (isYouth ? 'Youth' : 'Hattrick');
+				'&SourceSystem=' + sourceSystem;
 
 			var liveImg = doc.createElement('img');
 			liveImg.className = 'matchHTLive';
@@ -191,7 +215,7 @@ Foxtrick.util.matchView.fillMatches = function(container, xml, errorText) {
 		if (!matchXML)
 			continue;
 
-		var type = xml.text('MatchType', matchXML);
+		var type = mapNtType(xml.text('MatchType', matchXML));
 		var typeInfo = getMatchInfo(matchXML);
 
 		var matchId = xml.num('MatchID', matchXML);

--- a/content/util/match-view.js
+++ b/content/util/match-view.js
@@ -7,10 +7,9 @@
 
 'use strict';
 
-/* eslint-disable */
 if (!this.Foxtrick)
+	// @ts-ignore
 	var Foxtrick = {};
-/* eslint-enable */
 
 if (!Foxtrick.util)
 	Foxtrick.util = {};
@@ -83,6 +82,7 @@ Foxtrick.util.matchView.fillMatches = function(container, xml, errorText) {
 
 	/**
 	 * Map HTO match type to NT match types
+	 * 
 	 * @param {number} type match type 
 	 * @return {number} match type
 	 */
@@ -115,8 +115,8 @@ Foxtrick.util.matchView.fillMatches = function(container, xml, errorText) {
 	// get last previous and first future match
 	playedMatches.reverse();
 	var displayed = Foxtrick.map(function(matches) {
-		// only supported types (no HTO)
-		return Foxtrick.nth(getMatchInfo, matches);
+		// only supported types
+		return Foxtrick.nth((type) => !!getMatchInfo(type), matches);
 	}, [playedMatches, notPlayedMatches]);
 
 	var nextMatchDate = displayed[1] ? xml.time('MatchDate', displayed[1]) : null;


### PR DESCRIPTION
closes #9 

This was primarily failing because CHPP matches.xml is no longer supposed to be used for NT/U21 matches.

Technically NT matches are now HTO SourceSystem and when accessed via matches.xml the MatchTypes will be HTO type rather than the NT types the code was expecting.

The existing code has been hacked to work around this, but we should really be using nationalteammatches.xml for this.

