### PR TITLE
Update sidebar box expanders

### DIFF
--- a/content/pages/match.js
+++ b/content/pages/match.js
@@ -678,13 +678,15 @@ Foxtrick.Pages.Match.addLiveOverviewListener = function(doc, callback) {
  * Add a box to the sidebar on the right.
  * Returns the added box.
  * Modeled on Foxtrick.addBoxToSidebar.
+ * 
  * @param  {document} doc
- * @param  {string}   title   the title of the box, will create one if inexists
- * @param  {Element}  content HTML node of the content
- * @param  {number}   prec    precedence of the box, the smaller, the higher
- * @return {Element}          box to be added to
+ * @param  {string}   title      the title of the box, will create one if inexists
+ * @param  {Element}  content    HTML node of the content
+ * @param  {number}   prec       precedence of the box, the smaller, the higher
+ * @param  {boolean}  isExpander add expander icon and event to box header
+ * @return {Element}             box to be added to
  */
-Foxtrick.Pages.Match.addBoxToSidebar = function(doc, title, content, prec) {
+Foxtrick.Pages.Match.addBoxToSidebar = function(doc, title, content, prec, isExpander) {
 	if (this.isPrematch(doc)) {
 		// redirect to old style in prematch
 		return Foxtrick.addBoxToSidebar(doc, title, content, prec);
@@ -717,6 +719,14 @@ Foxtrick.Pages.Match.addBoxToSidebar = function(doc, title, content, prec) {
 		// boxHead
 		var boxHead = doc.createElement('div');
 		dest.appendChild(boxHead);
+
+		if (isExpander) {
+			Foxtrick.addClass(boxHead, 'ft-expander-unexpanded');
+			Foxtrick.onClick(boxHead, () => {
+				Foxtrick.toggleClass(boxHead, 'ft-expander-expanded');
+				Foxtrick.toggleClass(boxHead, 'ft-expander-unexpanded');
+			});
+		}
 
 		// header
 		var header = doc.createElement('h4');

--- a/content/presentation/team-select-box.js
+++ b/content/presentation/team-select-box.js
@@ -34,18 +34,9 @@ Foxtrick.modules['TeamSelectBox'] = {
 		});
 		listBox = linkBoxes[0];
 
-		// add headerClick
 		var header = listBox.getElementsByTagName('h2')[0];
-		var pn = header.parentNode;
-		var div = null;
-		if (pn.className != 'boxLeft') {
-			var hh = pn.removeChild(header);
-			div = Foxtrick.createFeaturedElement(doc, this, 'div');
-			div.appendChild(hh);
-			pn.insertBefore(div, pn.firstChild);
-		}
-		else
-			div = pn.parentNode;
+		var boxHead = header.parentNode;
+		Foxtrick.addBoxToSidebar(doc, header.textContent, null, 0, false, true)
 
 		var toList = function() {
 			var option = listBox.getElementsByTagName('option')[0];
@@ -78,7 +69,10 @@ Foxtrick.modules['TeamSelectBox'] = {
 			var players = listBox.getElementsByTagName('a');
 			for (var i = 0; i < players.length; ++i) {
 				var player = players[i];
-				var option = doc.createElement('option');
+				if (player.href.trim().length == 0)
+					continue;
+
+				option = doc.createElement('option');
 				option.value = player.href;
 				option.textContent = player.textContent;
 				selectBox.appendChild(option);
@@ -101,20 +95,13 @@ Foxtrick.modules['TeamSelectBox'] = {
 		var toggle = function() {
 			try {
 				showAsList = !showAsList;
-				if (showAsList) {
-					toList();
-					div.className = 'boxHead ft-expander-expanded';
-				}
-				else {
-					toSelectBox();
-					div.className = 'boxHead ft-expander-unexpanded';
-				}
+				(showAsList) ? toList() : toSelectBox();
 			}
 			catch (e) {
 				Foxtrick.log(e);
 			}
 		};
-		Foxtrick.onClick(div, toggle);
+		Foxtrick.onClick(boxHead, toggle);
 		toggle();
 	}
 };

--- a/content/resources/css/foxtrick.css
+++ b/content/resources/css/foxtrick.css
@@ -175,51 +175,46 @@ html[dir="rtl"] .date { padding-right: initial; }
 div.rightHandBoxBody > div {
 	margin: 10px 0;
 }
-/*
- * expanders
- * TODO - use attribute expanded to denote whether expanded
- */
 
-h2.ft-expander-unexpanded, h2.ft-expander-expanded,
-div.ft-expander-unexpanded h2, div.ft-expander-expanded h2,
-h4.ft-expander-unexpanded, h4.ft-expander-expanded,
-div.ft-expander-unexpanded h4, div.ft-expander-expanded h4 {
+/* expanders */
+div.ft-expander-unexpanded, div.ft-expander-expanded,
+h2.ft-expander-unexpanded, h2.ft-expander-expanded {
 	cursor: pointer;
+}
+
+div.ft-expander-unexpanded h4, div.ft-expander-expanded h4,
+h2.ft-expander-unexpanded, h2.ft-expander-expanded {
 	background-repeat: no-repeat;
 }
+
+div.ft-expander-unexpanded h4 {
+	background-image: url("chrome://foxtrick/content/resources/img/link-down.png");
+}
+div.ft-expander-expanded h4 {
+	background-image: url("chrome://foxtrick/content/resources/img/link-up.png");
+}
+
+h2.ft-expander-unexpanded {
+	background-image: url("chrome://foxtrick/content/resources/img/down.gif");
+}
+h2.ft-expander-expanded {
+	background-image: url("chrome://foxtrick/content/resources/img/up.gif");
+}
+
 html[dir="ltr"] h2.ft-expander-unexpanded, html[dir="ltr"] h2.ft-expander-expanded,
-html[dir="ltr"] div.ft-expander-unexpanded h2, html[dir="ltr"] div.ft-expander-expanded h2,
-html[dir="ltr"] h4.ft-expander-unexpanded, html[dir="ltr"] h4.ft-expander-expanded,
 html[dir="ltr"] div.ft-expander-unexpanded h4, html[dir="ltr"] div.ft-expander-expanded h4 {
 	background-position: right;
 }
 html[dir="rtl"] h2.ft-expander-unexpanded, html[dir="rtl"] h2.ft-expander-expanded,
-html[dir="rtl"] div.ft-expander-unexpanded h2, html[dir="rtl"] div.ft-expander-expanded h2,
-html[dir="rtl"] h4.ft-expander-unexpanded, html[dir="rtl"] h4.ft-expander-expanded,
 html[dir="rtl"] div.ft-expander-unexpanded h4, html[dir="rtl"] div.ft-expander-expanded h4 {
 	background-position: left;
 }
 
-/* div expanders */
-div.ft-expander-unexpanded h2, div.ft-expander-unexpanded h4 {
-	background-image: url("chrome://foxtrick/content/resources/img/link-down.png");
+div.ft-expander-unexpanded i.icon-caret-up {
+	display: none;
 }
-div.ft-expander-expanded h2, div.ft-expander-expanded h4 {
-	background-image: url("chrome://foxtrick/content/resources/img/link-up.png");
-}
-
-/* h2/h3 expanders */
-h2.ft-expander-unexpanded, h3.ft-expander-unexpanded {
-	background-image: url("chrome://foxtrick/content/resources/img/down.gif");
-}
-h2.ft-expander-expanded, h3.ft-expander-expanded {
-	background-image: url("chrome://foxtrick/content/resources/img/up.gif");
-}
-html[dir="ltr"] h3.ft-expander-unexpanded, html[dir="ltr"] h3.ft-expander-expanded {
-	padding-right: 20px;
-}
-html[dir="rtl"] h3.ft-expander-unexpanded, html[dir="rtl"] h3.ft-expander-expanded {
-	padding-right: 20px;
+div.ft-expander-expanded i.icon-caret-down{
+	display: none;
 }
 
 /*Forum HighlighthreadOpener PostID*/

--- a/content/util/dom.js
+++ b/content/util/dom.js
@@ -762,17 +762,20 @@ Foxtrick.getChanges = function(node, callback, obsOpts) {
 
 /**
  * Add a box to the sidebar, either on the right or on the left.
+ * If box with title already exists, method adds content and expander. 
  * Returns the added box.
+ * 
  * @author Ryan Li, LA-MJ
  * @param  {document} doc
- * @param  {string}   title       the title of the box, will create one if inexists
- * @param  {Element}  content     HTML node of the content
- * @param  {number}   prec        precedence of the box, the smaller, the higher
- * @param  {boolean}  [forceLeft] force the box to be displayed on the left
- * @return {Element}              box to be added to
+ * @param  {string}   title        the title of the box, will create one if inexists
+ * @param  {Element}  content      HTML node of the content
+ * @param  {number}   prec         precedence of the box, the smaller, the higher
+ * @param  {boolean}  [forceLeft]  force the box to be displayed on the left
+ * @param  {boolean}  [isExpander] add expander icon and event to box header
+ * @return {Element}               box to be added to
  */
 // eslint-disable-next-line complexity
-Foxtrick.addBoxToSidebar = function(doc, title, content, prec, forceLeft) { // FIXME support angular
+Foxtrick.addBoxToSidebar = function(doc, title, content, prec, forceLeft, isExpander) { // FIXME support angular
 	// class of the box to add
 	var boxClass = 'sidebarBox';
 	var sidebar = doc.getElementById('sidebar');
@@ -811,33 +814,20 @@ Foxtrick.addBoxToSidebar = function(doc, title, content, prec, forceLeft) { // F
 		boxHead.className = 'boxHead';
 		dest.appendChild(boxHead);
 
-		// boxHead - boxLeft
-		let headBoxLeft = doc.createElement('div');
-		headBoxLeft.className = 'boxLeft';
-		boxHead.appendChild(headBoxLeft);
-
-		// boxHead - boxLeft - h2
+		// boxHead - h2
 		let h2 = doc.createElement('h2');
 		h2.textContent = title;
-		headBoxLeft.appendChild(h2);
+		boxHead.appendChild(h2);
 
 		// boxBody
 		let boxBody = doc.createElement('div');
 		boxBody.className = 'boxBody';
 		dest.appendChild(boxBody);
 
-		// append content to boxBody
-		boxBody.appendChild(content);
-
 		// boxFooter
 		let boxFooter = doc.createElement('div');
 		boxFooter.className = 'boxFooter';
 		dest.appendChild(boxFooter);
-
-		// boxFooter - boxLeft
-		let footBoxLeft = doc.createElement('div');
-		footBoxLeft.className = 'boxLeft';
-		boxFooter.appendChild(footBoxLeft);
 
 		// now we insert the newly created box
 		var inserted = false;
@@ -864,8 +854,34 @@ Foxtrick.addBoxToSidebar = function(doc, title, content, prec, forceLeft) { // F
 			sidebar.appendChild(dest);
 	}
 
+	if (isExpander) {
+		let boxHead = dest.querySelector('.boxHead');
+		if (boxHead && !dest.querySelector('[class^="ft-expander"]')) {
+			Foxtrick.addClass(boxHead, 'ft-expander-unexpanded');
+
+			let iconDown = doc.createElement('i');
+			iconDown.classList.add('icon-caret-down');
+			let iconUp = doc.createElement('i');
+			iconUp.classList.add('icon-caret-up');
+
+			let anchor = doc.createElement('a');
+			anchor.append(iconDown, iconUp);
+
+			let span = doc.createElement('span');
+			span.classList.add('header-right');
+			span.append(anchor);
+
+			Foxtrick.onClick(boxHead, () => {
+				Foxtrick.toggleClass(boxHead, 'ft-expander-expanded');
+				Foxtrick.toggleClass(boxHead, 'ft-expander-unexpanded');
+			});
+			boxHead.append(span);
+		}
+	}
+
 	// finally we add the content
-	dest.querySelector('.boxBody').appendChild(content);
+	if (content)
+		dest.querySelector('.boxBody').appendChild(content);
 
 	return dest;
 };

--- a/content/util/links-box.js
+++ b/content/util/links-box.js
@@ -31,7 +31,7 @@ Foxtrick.util.links.add = function(ownBoxBody, customLinkSet, info, hasNewSideba
 		// save info for reuse
 		ownBoxBody.dataset.linkInfo = JSON.stringify(info);
 
-		var expanded = false;
+		var expanded = true;
 
 		/** @type {Listener<HTMLElement, MouseEvent>} */
 		var headerClick = function() {
@@ -39,8 +39,6 @@ Foxtrick.util.links.add = function(ownBoxBody, customLinkSet, info, hasNewSideba
 			let doc = this.ownerDocument;
 
 			try {
-				expanded = !expanded;
-
 				// remove old
 				let editbox = doc.getElementById('ft-edit-links');
 				if (editbox)
@@ -59,6 +57,8 @@ Foxtrick.util.links.add = function(ownBoxBody, customLinkSet, info, hasNewSideba
 					Foxtrick.util.links.showEdit(doc, ownBoxBody, customLinkSet);
 				else
 					Foxtrick.util.links.showLinks(doc, ownBoxBody, customLinkSet);
+				
+				expanded = !expanded;
 			}
 			catch (e) {
 				Foxtrick.log(e);
@@ -78,16 +78,9 @@ Foxtrick.util.links.add = function(ownBoxBody, customLinkSet, info, hasNewSideba
 			let header = sidebar.querySelector(headerTag);
 			if (header.textContent != l10nBoxHeader)
 				return false;
-
-			let hh = Foxtrick.cloneElement(header, true);
-			let div = doc.createElement('div');
-			div.appendChild(hh);
-			div.setAttribute('aria-label', div.title = l10nCustomLinkTitle);
-
-			Foxtrick.onClick(div, headerClick);
-
-			let pn = header.parentNode;
-			pn.replaceChild(div, header);
+			let parentNode = /**@type {HTMLElement}*/(header.parentNode);
+			parentNode.setAttribute('aria-label', parentNode.title = l10nCustomLinkTitle);
+			Foxtrick.onClick(parentNode, headerClick);
 			return true;
 		}, allDivs);
 
@@ -136,10 +129,6 @@ Foxtrick.util.links.showLinks = function(doc, ownBoxBody, linkSet) {
 		let box = doc.getElementById(ownBoxId);
 		if (!box)
 			return;
-
-		let div = box.firstElementChild;
-		Foxtrick.removeClass(div, 'ft-expander-unexpanded');
-		Foxtrick.addClass(div, 'ft-expander-expanded');
 
 		let delLinks = ownBoxBody.querySelectorAll('.foxtrickRemove');
 		for (let delLink of delLinks)
@@ -194,11 +183,10 @@ Foxtrick.util.links.showEdit = function(doc, ownBoxBody, linkSet) {
 	// TODO convert into a class
 	try {
 		{
-			// box
 			let ownBoxId = 'ft-links-box';
-			let expander = doc.getElementById(ownBoxId).firstElementChild;
-			Foxtrick.removeClass(expander, 'ft-expander-expanded');
-			Foxtrick.addClass(expander, 'ft-expander-unexpanded');
+			let box = doc.getElementById(ownBoxId);
+			if (!box)
+				return;
 
 			let delLinks = ownBoxBody.querySelectorAll('.foxtrickRemove');
 			for (let delLink of delLinks)
@@ -757,12 +745,14 @@ Foxtrick.util.links.run = function(doc, module) {
 
 	}).catch(Foxtrick.catch('links.run.custom'));
 
-	let adder = o.hasNewSidebar ? Foxtrick.Pages.Match : Foxtrick;
+	let sidebarBox;
+	if (o.hasNewSidebar) 
+		sidebarBox = Foxtrick.Pages.Match.addBoxToSidebar(doc, HEADER, box, -20, true);
+	else
+		sidebarBox = Foxtrick.addBoxToSidebar(doc, HEADER, box, -20, false, true);
 
-	// eslint-disable-next-line no-magic-numbers
-	let wrapper = adder.addBoxToSidebar(doc, HEADER, box, -20);
-	if (wrapper)
-		wrapper.id = 'ft-links-box';
+	if (sidebarBox)
+		sidebarBox.id = 'ft-links-box';
 };
 
 /**


### PR DESCRIPTION
closes #38 closes #39 

We switch to hattrick's html and style for these:

Here's how it looks with the style update from #42 :
![image](https://github.com/user-attachments/assets/7792aab9-a799-4c6d-94c9-a98333b719af)

Team select box:
![image](https://github.com/user-attachments/assets/d68af6be-dddc-4827-8fa1-3bb38f703a8a)



