### PR TITLE
fix removal of empty space below calendar

### DIFF
--- a/content/resources/css/my-monitor.css
+++ b/content/resources/css/my-monitor.css
@@ -76,7 +76,7 @@ html[dir="rtl"] .teamIcon {
 .ft-monitor-frame > h3 > a.flag + img {
 	margin-top:-2px;
 }
-#eventList {
+
+div.calendarWrapperOuter {
 	min-height: 0px;
 }
-


### PR DESCRIPTION
As discussed in #28 

gets rid of this space:
![Screenshot](https://github.com/user-attachments/assets/92759ec3-c630-4db2-9afd-c137219f22a3)