### PR TITLE
remove link to Inbox in NewMail

### DIFF
--- a/content/alert/new-mail.js
+++ b/content/alert/new-mail.js
@@ -49,16 +49,6 @@ Foxtrick.modules['NewMail'] = {
 		if (myHt.getElementsByTagName('span').length) {
 			let mailCountSpan = myHt.getElementsByTagName('span')[0];
 			mailCountSpan.className = 'ft-new-mail';
-
-			Foxtrick.onClick(mailCountSpan, function() {
-				let doc = this.ownerDocument;
-				let newURL = new URL('/MyHattrick/Inbox/', doc.location.origin);
-				doc.location.assign(newURL);
-
-				// disable MyHT link
-				return false;
-			});
-
 			newMailCount = parseInt(mailCountSpan.textContent.match(/\d+/)[0], 10) || 0;
 		}
 


### PR DESCRIPTION
On the notification icon by 'My Clubs' Foxtrick adds an onClick event that redirects the page to the ht-mail Inbox.
![image](https://github.com/user-attachments/assets/79cc3799-6040-41df-bdd3-cd94b25ca38c)

Given that icon notifies for both news and ht-mail, I don't think it makes sense to have a link to the Inbox there.
