### PR TITLE
fix: Remove thousands separator

### DIFF
--- a/content/shortcuts-and-tweaks/confirm-actions.js
+++ b/content/shortcuts-and-tweaks/confirm-actions.js
@@ -142,8 +142,7 @@ Foxtrick.modules.ConfirmActions = {
 			let confirm = doc.getElementById('ft-sell-confirm');
 			if (sellText && !confirm) {
 				let msgTemplate = Foxtrick.L10n.getString('ConfirmActions.transferlist');
-				let price = sellText.value.replace(/\s/g,'').replace(/\B(?=(\d{3})+(?!\d))/g, NBSP);
-				let msg = msgTemplate.replace(/%s/, price);
+				let msg = msgTemplate.replace(/%s/, sellText.value);
 				let msgPara = doc.createElement('p');
 				if (Foxtrick.util.layout.hasMultipleTeams(doc)) {
 					let cont = doc.createElement('strong');


### PR DESCRIPTION
<img width="281" alt="Screenshot 2025-01-04 at 12 24 03" src="https://github.com/user-attachments/assets/2a346b23-68d8-4404-8272-60cdaedcd54c" />

This PR is about to remove thousands separator replacer logic for TL as it's already implemented in value of the text area.