### PR TITLE
move psicotsi back into mainbody on player page

### DIFF
--- a/content/information-aggregation/psico-tsi.js
+++ b/content/information-aggregation/psico-tsi.js
@@ -91,7 +91,7 @@ Foxtrick.modules['PsicoTSI'] = {
 			return;
 
 		var p = Foxtrick.Pages.Player.getSkills(doc);
-		var entryPoint = doc.querySelector('.ownerAndStatusPlayerInfo ~ .flex') ||
+		var entryPoint = doc.querySelector('#mainBody > .separator') ||
 			Foxtrick.getMBElement(doc, 'updBestLatest') ||
 			Foxtrick.getMBElement(doc, 'updPlayerTabs');
 


### PR DESCRIPTION
Like so:

![image](https://github.com/user-attachments/assets/a165f66a-6c97-43ee-8ef5-ab5fba37a05e)

closes #56 
