### PR TITLE
fix delayed loading for ng-apps without mainBody div

### DIFF
--- a/content/entry.js
+++ b/content/entry.js
@@ -180,7 +180,7 @@ Foxtrick.entry.run = function(doc) {
 		if (shouldDelay) {
 			promise = new Promise((resolve) => {
 				Foxtrick.onChange(ngApp, (doc, app) => {
-					if (!doc.getElementById('mainBody'))
+					if (!doc.getElementById('mainBody') && !app.getElementsByTagName('ht-mainbox').length)
 						return false;
 
 					if (app.getElementsByTagName('ht-loading').length)


### PR DESCRIPTION
For hattrick pages that dynamically load content into the main body of the page, Foxtrick delays module initialisation until that content appears.

This was not functioning correctly for pages that use angular for the main body content, as they use an `<ht-mainbox>` element rather than `<div id="mainBody">`

The Training page would be an example of this.
