### PR TITLE
fix series page overlap of prior and next round tables

### DIFF
--- a/content/information-aggregation/show-lineup-set.js
+++ b/content/information-aggregation/show-lineup-set.js
@@ -100,7 +100,6 @@ Foxtrick.modules.ShowLineupSet = {
 			var teamNode1 = doc.createElement('span');
 			teamNode1.textContent = teams[1];
 
-			Foxtrick.addClass(matchLink, 'nowrap');
 			matchLink.textContent = '';
 			matchLink.appendChild(teamNode0);
 			matchLink.appendChild(doc.createTextNode('\u00a0-\u00a0'));


### PR DESCRIPTION
closes #67 

Simply removed the `whitespace: nowrap` CSS added by ShowLineupSet.

Before:
![Image](https://github.com/user-attachments/assets/15ed48a2-2a48-42c0-b156-c5df60168e73)

After:
![image](https://github.com/user-attachments/assets/6a224a2b-0961-4f04-b085-02861fd7db81)

