### PR TITLE
fix wide tables in forum posts overflowing the container

### DIFF
--- a/content/resources/css/popup-links.css
+++ b/content/resources/css/popup-links.css
@@ -95,7 +95,7 @@ ul.ft-popup-list > li:hover {
 	display: none;
 }
 
-div.cfMessage, div.edited, div.cfHeader, div.feedItem, div.cfUserInfo, div.signature,
+div.edited, div.cfHeader, div.feedItem, div.cfUserInfo, div.signature,
 div.playerInfo, .alert, .tournamentInvite, .frontPageList, .teamName, .fplMessageAuthor {
 	overflow: visible;
 }


### PR DESCRIPTION
closes #69 

Simply removed TeamPopupLinks overflow:visible css for forum message body.  It is possible this may cause issues with team/manager popups in forum messages, but I was unable to produce any.
<!-- Please review the contributing guidelines before submitting this PR. -->
