### PR TITLE
disable TableSort on Series table until it is fixed properly

### DIFF
--- a/content/shortcuts-and-tweaks/table-sort.js
+++ b/content/shortcuts-and-tweaks/table-sort.js
@@ -227,7 +227,7 @@ Foxtrick.modules.TableSort = {
 			tables = doc.querySelectorAll('#mainBody table');
 
 		for (let table of tables) {
-			if (table.id == 'ft_skilltable' || Foxtrick.hasClass(table, 'tablesorter'))
+			if (table.id == 'ft_skilltable' || Foxtrick.hasClass(table, 'league-table') || Foxtrick.hasClass(table, 'tablesorter'))
 				continue;
 
 			let ths = table.querySelectorAll('th');


### PR DESCRIPTION
Given that TableSort has serious issues when sorting the Series tables, including the possibility of making the browser completely unresponsive, we disable it on Series tables until #13 is resolved.
<!-- Please review the contributing guidelines before submitting this PR. -->
