### PR TITLE
point to new CDN url

### DIFF
--- a/content/env.js
+++ b/content/env.js
@@ -522,7 +522,7 @@ if (Foxtrick.platform !== 'Android') {
 	// branch cannot be accessed so early so we need a lazy getter
 	(function() {
 		var localDataPath = Foxtrick.DataPath;
-		var remoteDataPath = 'https://cdn.rawgit.com/minj/foxtrick/res/%d/res/';
+		var remoteDataPath = 'https://foxtrick-ng.github.io/foxtrick/';
 		Foxtrick.lazyProp(Foxtrick, 'DataPath', function() {
 			if (Foxtrick.branch !== 'dev')
 				return remoteDataPath;

--- a/defaults/preferences/foxtrick.js
+++ b/defaults/preferences/foxtrick.js
@@ -192,7 +192,7 @@ pref("extensions.foxtrick.prefs.module.LastLogin.enabled", true);
 pref("extensions.foxtrick.prefs.module.LeagueNewsFilter.enabled", true);
 pref("extensions.foxtrick.prefs.module.LeagueNewsFilter.value", 0);
 pref("extensions.foxtrick.prefs.module.LineupShortcut.enabled", true);
-pref("extensions.foxtrick.prefs.module.Links.feedsList", "https://cdn.rawgit.com/minj/foxtrick/res/%d/res/links.json");
+pref("extensions.foxtrick.prefs.module.Links.feedsList", "https://foxtrick-ng.github.io/foxtrick/links.json");
 pref("extensions.foxtrick.prefs.module.Links.ReuseTab.enabled", false);
 pref("extensions.foxtrick.prefs.module.LinksAchievements.enabled", true);
 pref("extensions.foxtrick.prefs.module.LinksAlliances.enabled", true);


### PR DESCRIPTION
We switch from using the old CDN on minj's repo, to foxtrick-ng/foxtrick accessed via GitHub Pages.

closes #14