### PR TITLE
fix SupportershipExpirationDate

### DIFF
--- a/content/shortcuts-and-tweaks/supportership-expiration-date.js
+++ b/content/shortcuts-and-tweaks/supportership-expiration-date.js
@@ -18,7 +18,7 @@ Foxtrick.modules['SupportershipExpirationDate'] = {
 
 		// get the content, translate days to date
 		let packageType =
-			doc.getElementById('ctl00_ctl00_CPContent_CPSidebar_pnlSubscriptionPackageType');
+			doc.getElementById('ctl00_ctl00_CPContent_CPSidebar_ucMyAccount_pnlSubscriptionPackageType');
 
 		if (!packageType)
 			return;
@@ -26,7 +26,9 @@ Foxtrick.modules['SupportershipExpirationDate'] = {
 		let box = packageType.closest('.sidebarBox');
 
 		/** @type {HTMLElement} */
-		let container = box.querySelector('.myAccountCounter .flex-grow');
+		let container = box.querySelector('#ctl00_ctl00_CPContent_CPSidebar_ucMyAccount_pnlSupporter');
+		if (!container)
+			return;
 
 		// feature highlight
 		Foxtrick.makeFeaturedElement(container, this);


### PR DESCRIPTION
Restores ability in My Office to click on remaining days of supporter and see the date it expires.

Obviously, I can only test this for my supporter level (diamond).  I'd appreciate anyone with silver/gold/platinum could look at the updated queryselectors and confirm they are the same for their level.  More importantly we should double-check that the code will return early for non-supporters.
