### PR TITLE
Bugfix/table sort series

### DIFF
--- a/content/shortcuts-and-tweaks/table-sort.js
+++ b/content/shortcuts-and-tweaks/table-sort.js
@@ -49,18 +49,25 @@ Foxtrick.modules.TableSort = {
 				}
 				table.setAttribute('lastSortIndex', String(index));
 
-				// get text to sort by. first try textContent, then title
+				// get text to sort by. first try textContent, then title, then alt
 				/**
 				 * @param  {HTMLTableCellElement} el
 				 * @return {string}
 				 */
 				var getText = function(el) {
-					var text = el.textContent.trim() || el.title.trim();
+					var text = el.textContent.trim();
 					if (text == '') {
-						// use first title instead
-						/** @type {HTMLElement} */
-						let tEl = el.querySelector('[title]');
-						text = tEl && tEl.title.trim() || '';
+						for (let att of ['title', 'alt']) {
+							text = el.getAttribute(`${att}`) ? el.getAttribute(`${att}`).trim() : '';
+							if (text != '')
+								break;
+							// check descendent nodes
+							let tEl = el.querySelector(`[${att}]`);
+							if (tEl)
+								text = tEl.getAttribute(`${att}`).trim();
+							if (text != '')
+								break;
+						}
 					}
 					return text;
 				};

--- a/content/shortcuts-and-tweaks/table-sort.js
+++ b/content/shortcuts-and-tweaks/table-sort.js
@@ -121,7 +121,7 @@ Foxtrick.modules.TableSort = {
 				// rows to be sorted
 				var rows = [];
 				for (let i = sortStart + 1; i < sortEnd; ++i)
-					rows.push(Foxtrick.cloneElement(table.rows[i], true));
+					rows.push(table.rows[i]);
 
 				/**
 				 * @param  {HTMLTableRowElement} a
@@ -209,11 +209,10 @@ Foxtrick.modules.TableSort = {
 				// sort them
 				rows.sort(cmp);
 
-				// put them back
-				for (let i = sortStart + 1; i < sortEnd; ++i) {
-					table.rows[i].parentNode.replaceChild(rows[i - 1 - sortStart], table.rows[i]);
-					table.rows[i].setAttribute('lastSort', String(i));
-				}
+				// insert sorted rows after table header
+				// no need to remove existing rows, inserting a Node removes it from its previous position
+				/** @type  {HTMLElement} */
+				(table.rows[sortStart].parentNode).after(...rows);
 			}
 			catch (e) {
 				Foxtrick.log(e);
@@ -227,7 +226,7 @@ Foxtrick.modules.TableSort = {
 			tables = doc.querySelectorAll('#mainBody table');
 
 		for (let table of tables) {
-			if (table.id == 'ft_skilltable' || Foxtrick.hasClass(table, 'league-table') || Foxtrick.hasClass(table, 'tablesorter'))
+			if (table.id == 'ft_skilltable' || Foxtrick.hasClass(table, 'tablesorter'))
 				continue;
 
 			let ths = table.querySelectorAll('th');


### PR DESCRIPTION
See #13 

Performing cloneNode and then inserting nodes that contain hattrick tooltips and such causes all sorts of problems.  We
switch to an implementation that re-inserts the existing tr nodes.

Also, allow columns to be sorted on image alt text when no text content or title attribute is found.

