### PR TITLE
add module LinksFlags

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -184,6 +184,7 @@ a good reason to. They are for version bumps in Makefile.
 				<string>content/links/links-country.js</string>
 				<string>content/links/links-economy.js</string>
 				<string>content/links/links-fans.js</string>
+				<string>content/links/links-flags.js</string>
 				<string>content/links/links-league.js</string>
 				<string>content/links/links-manager.js</string>
 				<string>content/links/links-match.js</string>

--- a/content/background.html
+++ b/content/background.html
@@ -135,6 +135,7 @@
 	<script type="application/x-javascript" src="./links/links-country.js"></script>
 	<script type="application/x-javascript" src="./links/links-economy.js"></script>
 	<script type="application/x-javascript" src="./links/links-fans.js"></script>
+	<script type="application/x-javascript" src="./links/links-flags.js"></script>
 	<script type="application/x-javascript" src="./links/links-league.js"></script>
 	<script type="application/x-javascript" src="./links/links-manager.js"></script>
 	<script type="application/x-javascript" src="./links/links-match.js"></script>

--- a/content/foxtrick.properties
+++ b/content/foxtrick.properties
@@ -138,6 +138,7 @@ module.LinksAchievements.desc=Adds some external links to the achievements page
 module.LinksTracker.desc=Adds some external tracker links to the corresponding NT pages and player pages
 module.LinksClubTransfers.desc=Adds some external links to the club transfer page
 module.LinksWorld.desc=Adds some external links to the world page
+module.LinksFlags.desc=Adds some external links to the flag collection page
 module.LoyaltyDisplay.desc=Highlight the effect of loyalty and mother club bonus on your personal player page (Works only with 'Show skill bars' option enabled in HT preferences)
 module.ForumAlterHeaderLine.desc=Alters posting header line
 module.ForumAlterHeaderLine.SingleHeaderLine.desc=Forces single-line forum posting headers even when detailed headers are enabled.

--- a/content/links/links-flags.js
+++ b/content/links/links-flags.js
@@ -1,0 +1,32 @@
+'use strict';
+/**
+ * linksflags.js
+ * Foxtrick add links to flag collection page
+ * @author convinced, LA-MJ, UnnecessaryDave
+ */
+
+Foxtrick.modules['LinksFlags'] = {
+	MODULE_CATEGORY: Foxtrick.moduleCategories.LINKS,
+	PAGES: ['flagCollection'],
+	LINK_TYPES: ['flagslink'],
+	/**
+	 * return HTML for FT prefs
+	 * @param  {document}         doc
+	 * @param  {function}         cb
+	 * @return {HTMLUListElement}
+	 */
+	OPTION_FUNC: function(doc, cb) {
+		return Foxtrick.util.links.getPrefs(doc, this, cb);
+	},
+
+	run: function(doc) {
+		Foxtrick.util.links.run(doc, this);
+	},
+
+	links: function(doc) {
+		var teamId = Foxtrick.Pages.All.getTeamId(doc);
+		var info = { teamId: teamId };
+
+        return { info: info };
+	}
+};

--- a/content/preferences.html
+++ b/content/preferences.html
@@ -142,6 +142,7 @@
 	<script type="application/x-javascript" src="./links/links-country.js"></script>
 	<script type="application/x-javascript" src="./links/links-economy.js"></script>
 	<script type="application/x-javascript" src="./links/links-fans.js"></script>
+	<script type="application/x-javascript" src="./links/links-flags.js"></script>
 	<script type="application/x-javascript" src="./links/links-league.js"></script>
 	<script type="application/x-javascript" src="./links/links-manager.js"></script>
 	<script type="application/x-javascript" src="./links/links-match.js"></script>

--- a/defaults/preferences/foxtrick.js
+++ b/defaults/preferences/foxtrick.js
@@ -203,6 +203,7 @@ pref("extensions.foxtrick.prefs.module.LinksCoach.enabled", true);
 pref("extensions.foxtrick.prefs.module.LinksCountry.enabled", true);
 pref("extensions.foxtrick.prefs.module.LinksEconomy.enabled", true);
 pref("extensions.foxtrick.prefs.module.LinksFans.enabled", true);
+pref("extensions.foxtrick.prefs.module.LinksFlags.enabled", true);
 pref("extensions.foxtrick.prefs.module.LinksLeague.enabled", true);
 pref("extensions.foxtrick.prefs.module.LinksManager.enabled", true);
 pref("extensions.foxtrick.prefs.module.LinksMatch.enabled", true);

--- a/manifest.json
+++ b/manifest.json
@@ -170,6 +170,7 @@
 			"content/links/links-country.js",
 			"content/links/links-economy.js",
 			"content/links/links-fans.js",
+			"content/links/links-flags.js",
 			"content/links/links-league.js",
 			"content/links/links-manager.js",
 			"content/links/links-match.js",

--- a/modules
+++ b/modules
@@ -67,6 +67,7 @@ links/links-coach.js
 links/links-country.js
 links/links-economy.js
 links/links-fans.js
+links/links-flags.js
 links/links-league.js
 links/links-manager.js
 links/links-match.js

--- a/res/links.json
+++ b/res/links.json
@@ -118,6 +118,19 @@
 		"title": "HT Flagtools",
 		"img": "https://www.foxtrick.org/res/linkicons/flagtools.ico"
 	},
+	"funwithflags": {
+		"challengeslink": {
+			"url": "https://hattrick-fun-with-flags.app/"
+		},
+		"teamlink": {
+			"url": "https://hattrick-fun-with-flags.app/"
+		},
+		"flagslink": {
+			"url": "https://hattrick-fun-with-flags.app/"
+		},
+		"title": "Fun with flags",
+		"img": "https://foxtrick-ng.github.io/foxtrick/linkicons/fwf.ico"
+	},
 	"fcc_logo_coolness": {
 		"teamlink": {
 			"url": "http://fcclogo.kaoztribe.net/Countries.php?teamid=[teamid]"

--- a/res/links.json
+++ b/res/links.json
@@ -112,6 +112,9 @@
 		"teamlink": {
 			"url": "http://www.ht-flagtools.org/profile.php?teamId=[teamid]"
 		},
+		"flagslink": {
+			"url": "http://www.ht-flagtools.org/profile.php?teamId=[teamid]"
+		},
 		"title": "HT Flagtools",
 		"img": "https://www.foxtrick.org/res/linkicons/flagtools.ico"
 	},


### PR DESCRIPTION
<!-- Please review the contributing guidelines before submitting this PR. -->
Add sidebar links to the Flag collection page.

also -
Add link to HT Flagtools on flag collection page.
Add links to Fun with flags on flag collection, challenges and team pages.