### PR TITLE
add module NotifyChromeVersion

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -116,6 +116,7 @@ a good reason to. They are for version bumps in Makefile.
 
 				<!-- categorized modules -->
 				<string>content/access/aria-landmarks.js</string>
+				<string>content/alert/chrome-version.js</string>
 				<string>content/alert/live-alert.js</string>
 				<string>content/alert/new-mail.js</string>
 				<string>content/alert/ticker-alert.js</string>

--- a/content/alert/chrome-version.js
+++ b/content/alert/chrome-version.js
@@ -1,0 +1,136 @@
+/**
+ * chromeversion.js
+ * Display a Foxtrick Note when a new chrome version is available.
+ * Temporary module while chrome users are installing in developer mode.
+ * @author UnnecessaryDave
+ */
+
+'use strict';
+
+Foxtrick.modules['NotifyChromeVersion'] = {
+    MODULE_CATEGORY: Foxtrick.moduleCategories.ALERT,
+    PAGES: ['dashboard'],
+
+    /**
+     * Firefox update.json url used to find the latest release version number
+     * - Chrome and Firefox version numbers are in sync.
+     */
+    UPDATE_JSON_URL: 'https://foxtrick-ng.github.io/download/release/firefox/update.json',
+    
+    /** Extension GUID */
+    GUID: '{bcfe9090-dfc6-41d6-a49c-127432ec04ea}', // release branch
+
+    /** Chrome update instructions url */
+    CHROME_UPDATE_URL: 'https://foxtrick-ng.github.io/chromeupgrade.html',
+
+    /** How often to check for updates (milliseconds) */
+    CHECK_INTERVAL: Foxtrick.util.time.MSECS_IN_DAY,
+
+    /**
+     * Session store key
+     * - Associated value is timestamp when update note was displayed.
+     */
+    SEEN_NOTE_KEY: `NotifyChromeVersion.seenUpdateNote`,
+
+    /**
+     * Session store key
+     * - Associated value is timestamp after which another check may be performed.
+     */
+    NEXT_CHECK_KEY: `NotifyChromeVersion.nextCheck`,
+
+    run: async function(doc) {
+        /** @ts-ignore */
+        if (!navigator.userAgentData) // only defined in chromium browsers
+            return;
+
+        const MODULE = this;
+        const log = MODULE.log.bind(MODULE);
+
+        /**
+         * Timestamp representing the current time
+         * - Foxtrick.load() uses UTC HT_TIME for comparisons, so we do the same.
+         */
+        const NOW = Foxtrick.modules.Core.HT_TIME || Date.now();
+
+        try {
+            // Only show note once per session.
+            const seenNoteTs = await Foxtrick.session.get(MODULE.SEEN_NOTE_KEY);
+            if (seenNoteTs) {
+                log(`Update note seen on ${new Date(seenNoteTs).toUTCString()}`);
+                return;
+            }
+
+            // Return if next check is not due.
+            const nextCheck = await Foxtrick.session.get(MODULE.NEXT_CHECK_KEY);
+            if (nextCheck && NOW <= nextCheck) {
+                log(`Next check: ${new Date(nextCheck).toUTCString()} | Now: ${new Date(NOW).toUTCString()}`);
+                return;
+            }
+
+            // Load update.json
+            log(`Loading ${MODULE.UPDATE_JSON_URL}`);
+            let jsonText;
+            try {
+                jsonText = await Foxtrick.load(MODULE.UPDATE_JSON_URL, undefined, NOW);
+            } catch (e) {
+                log(`Failed to load ${MODULE.UPDATE_JSON_URL}: ${e}`);
+                return;
+            }
+            Foxtrick.session.set(MODULE.NEXT_CHECK_KEY, NOW + MODULE.CHECK_INTERVAL);
+
+            // Parse updates array in json.
+            let updates;
+            try {
+                /** @ts-ignore - if jsonText is not a string, FetchError will be caught in try/catch above */
+                const json = JSON.parse(jsonText);
+                updates = json.addons?.[MODULE.GUID]?.updates;
+                if (!updates) throw new TypeError(`json.addons.[${MODULE.GUID}].updates not found`);
+            } catch (e) {
+                log(`Error parsing updates: ${e}`);
+                return;
+            }
+
+            // Find latest version.
+            let latestVersion = updates.reduce((maxVer, v) =>
+                v.version && v.version.localeCompare(maxVer) > 0 ? v.version : maxVer, '0');
+
+            // Display note if update available.
+            if (Foxtrick.version.localeCompare(latestVersion) < 0) {
+                MODULE.showUpdateNote(doc, latestVersion, NOW);
+            }
+        } catch (e) {
+            log(`Unexpected error: ${e}`);
+        }
+    },
+
+    // TODO: Internationalise once we can add new l10n keys.
+    showUpdateNote: function(doc, latestVersion, now) {
+        const MODULE = this;
+
+        const container = doc.createElement('div');
+        const p = doc.createElement('p');
+        container.appendChild(p);
+
+        const a = doc.createElement('a');
+        a.href = MODULE.CHROME_UPDATE_URL;
+        a.textContent = 'here';
+        a.target = '_blank';
+
+        p.innerHTML =
+            `A new version of Foxtrick is available: ${latestVersion}` +
+            doc.createElement('br').outerHTML +
+            ` - Click ${a.outerHTML} for update instructions.`;
+
+        Foxtrick.util.note.add(doc, container, 'ft-notify-chrome-version');
+        Foxtrick.session.set(MODULE.SEEN_NOTE_KEY, now);
+    },
+
+    /**
+     * Logging helper function
+     * - Uses Foxtrick.log() to log messages with the module name as prefix.
+     * @param {String} text - The message to log.
+     */
+    log: function(text) {
+        Foxtrick.log(`${this.MODULE_NAME || 'NotifyChromeVersion'}: ${text}`);
+    }
+};

--- a/content/background.html
+++ b/content/background.html
@@ -67,6 +67,7 @@
 
 	<!-- categorized modules -->
 	<script type="application/x-javascript" src="./access/aria-landmarks.js"></script>
+	<script type="application/x-javascript" src="./alert/chrome-version.js"></script>
 	<script type="application/x-javascript" src="./alert/live-alert.js"></script>
 	<script type="application/x-javascript" src="./alert/new-mail.js"></script>
 	<script type="application/x-javascript" src="./alert/ticker-alert.js"></script>

--- a/content/foxtrick.properties
+++ b/content/foxtrick.properties
@@ -10,6 +10,9 @@ direction=ltr
 #some strings use plural forms. for rules and pluralFormRuleID see https://developer.mozilla.org/en/Localization_and_Plurals
 pluralFormRuleID=pluralFormRule1
 
+#NotifyChromeVersion
+module.NotifyChromeVersion.desc=Show a note on Dashboard when a new chrome version of Foxtrick is available
+
 module.LineupShortcut.desc=Add a shortcut to lineup on player's match history
 module.ForumTemplates.desc=Allows turning forum posts into templates for later use (Also works for mails, tickets and Guestbook, editors)
 module.ForumTemplates.DefaultShow.desc=Shows or hides your templates by default

--- a/content/preferences.html
+++ b/content/preferences.html
@@ -74,6 +74,7 @@
 
 	<!-- categorized modules -->
 	<script type="application/x-javascript" src="./access/aria-landmarks.js"></script>
+	<script type="application/x-javascript" src="./alert/chrome-version.js"></script>
 	<script type="application/x-javascript" src="./alert/live-alert.js"></script>
 	<script type="application/x-javascript" src="./alert/new-mail.js"></script>
 	<script type="application/x-javascript" src="./alert/ticker-alert.js"></script>

--- a/defaults/preferences/foxtrick.js
+++ b/defaults/preferences/foxtrick.js
@@ -305,6 +305,7 @@ pref("extensions.foxtrick.prefs.module.NewMail.NotifyForumSound_text", 'foxtrick
 pref("extensions.foxtrick.prefs.module.NewMail.NotifyMail.enabled", true);
 pref("extensions.foxtrick.prefs.module.NewMail.NotifyMailSound.enabled", false);
 pref("extensions.foxtrick.prefs.module.NewMail.NotifyMailSound_text", 'foxtrick://resources/sounds/DingLing.wav');
+pref("extensions.foxtrick.prefs.module.NotifyChromeVersion.enabled", true);
 pref("extensions.foxtrick.prefs.module.NtPeek.enabled", true);
 pref("extensions.foxtrick.prefs.module.OldStyleFace.enabled", false);
 pref("extensions.foxtrick.prefs.module.OriginalFace.ColouredYouth.enabled", false);

--- a/manifest.json
+++ b/manifest.json
@@ -102,6 +102,7 @@
 
 			// <!-- categorized modules -->
 			"content/access/aria-landmarks.js",
+			"content/alert/chrome-version.js",
 			"content/alert/live-alert.js",
 			"content/alert/new-mail.js",
 			"content/alert/ticker-alert.js",

--- a/modules
+++ b/modules
@@ -1,4 +1,5 @@
 access/aria-landmarks.js
+alert/chrome-version.js
 alert/live-alert.js
 alert/new-mail.js
 alert/ticker-alert.js


### PR DESCRIPTION
Display a Note to chrome users when a new Foxtrick version is available.

- only in chromium browsers
- only on Dashboard
- only displays note once per session (browser restart)
- checks once every 24h

Like so:
![image](https://github.com/user-attachments/assets/61879dc1-2973-45bc-b454-b92dda1b1439)

<!-- Please review the contributing guidelines before submitting this PR. -->
