### PR TITLE
fix price parsing in bid confirmation

### DIFF
--- a/content/shortcuts-and-tweaks/confirm-actions.js
+++ b/content/shortcuts-and-tweaks/confirm-actions.js
@@ -235,9 +235,7 @@ Foxtrick.modules.ConfirmActions = {
 				let value = bidText[1] && bidText[1].value ||
 					bidText[0] && bidText[0].value;
 
-				let price = value.split('').reverse().join('');
-				price = price.replace(/(.{3})(?!$)/g, '$1' + NBSP);
-				price = price.split('').reverse().join('');
+				let price = value.replace(/\s/g,'').replace(/\B(?=(\d{3})+(?!\d))/g, NBSP);
 
 				let msg = msgTemplate.replace(/%s/, price);
 				let msgPara = doc.createElement('p');


### PR DESCRIPTION
closes #75

Simply mirrors the method used for transfer listing.

It might amuse people to know that I managed to accidentally buy a player when testing this.  Thankfully for 5,000 and not 5,000,000.

I don't think confirm bid works for setting max bids. If not, it would be nice if it did, but I won't be trying to test that until I actually need to buy players.