### PR TITLE
add functions to test if page is classic/legacy

### DIFF
--- a/content/core.js
+++ b/content/core.js
@@ -51,6 +51,8 @@ Foxtrick.modules.Core = {
 	run: function(doc) {
 		const CORE = this;
 
+		CORE.logPageViewType(doc);
+
 		CORE.addBugReportLink(doc);
 
 		CORE.monitorWeekChanges(doc);
@@ -563,5 +565,14 @@ Foxtrick.modules.Core = {
 	getPlayerList: function() {
 		return this.PLAYER_LIST;
 	},
+
+	/**
+	 * Log whether page view is classic and/or legacy
+	 * @param {Document} doc
+	 */
+	logPageViewType: function(doc) {
+		Foxtrick.Pages.All.isClassic(doc) && Foxtrick.log('Classic view detected');
+		Foxtrick.Pages.All.isLegacy(doc) && Foxtrick.log('Legacy page detected');
+	}
 
 };

--- a/content/pages/all.js
+++ b/content/pages/all.js
@@ -46,6 +46,46 @@ Foxtrick.Pages.All.isYouth = function(doc) {
 };
 
 /**
+ * Test whether the page is in HT classic mode
+ * @param {Document} doc
+ * @return {boolean}
+ */
+Foxtrick.Pages.All.isClassic = function (doc) {
+	return Foxtrick.hasClass(doc.querySelector('body'), 'classic');
+}
+
+/**
+ * Test whether the page is a legacy page
+ *
+ * Legacy pages are those from the old HT design,
+ * and do not imply classic mode.
+ * @param {Document} doc
+ * @returns {boolean}
+ */
+Foxtrick.Pages.All.isLegacy = function (doc) {
+	/** @type {PAGE[]} */
+	var LEGACY_PAGES = [
+		'matchOrder',
+		'matchStatus',
+		'matchesHistory',
+		'matchesLatest',
+		'matchReferees'
+	];
+	if (Foxtrick.isPage(doc, LEGACY_PAGES))
+		return true;
+
+	/** @type {PAGE[]} */
+	var NG_PAGES = [
+		'match',
+		'matchesLive'
+	];
+	if (Foxtrick.isPage(doc, NG_PAGES) && !doc.querySelector('ng-app'))
+		return true;
+
+	return false;
+}
+
+/**
  * Get the page ID.
  * E. g. match, arena, series, team, player ID.
  * Defaults to own team ID where no ID is avalable.


### PR DESCRIPTION
Convenience methods to detemine if a page is classic, if a page is legacy,

I know Hattrick renamed things recently, but as far as Foxtrick is concerned,

Classic refers to the **theme**, that just happens to also display certain pages differently:
![image](https://github.com/user-attachments/assets/ca14504c-bd30-4b90-9af3-4c7025377cd3)
Above image is classic, but not legacy.

Legacy is 'old hattrick':
![image](https://github.com/user-attachments/assets/610d78a8-81ba-43e3-aa22-3538a8f8407e)
Above image is legacy, but not classic (note the box header style).

One can, but does not always imply the other.  Classic view will display certain pages in legacy mode, but you can also be in non-classic mode and see legacy page content (usually by adding .classic in the url), or have legacy live/match-orders enabled.

- Two functions because it may sometimes be useful to distinguish between the two things
- If classic and/or legacy is detected it is logged - useful when dealing with exceptionless bug reports
