### PR TITLE
fix MyMonitor - error when trying to remove team from an empty team list

### DIFF
--- a/content/information-aggregation/my-monitor.js
+++ b/content/information-aggregation/my-monitor.js
@@ -365,14 +365,15 @@ Foxtrick.modules.MyMonitor = {
 				Foxtrick.onClick(removeButton, function() {
 					let index = removeSelect.selectedIndex;
 					let opt = removeSelect.options[index];
-					if (opt)
+					if (opt) {
 						removeSelect.removeChild(opt);
 
-					gTeams.splice(index, 1); // remove the selected from teams
-					setSavedTeams(gTeams);
+						gTeams.splice(index, 1); // remove the selected from teams
+						setSavedTeams(gTeams);
 
-					let frame = doc.getElementsByClassName('ft-monitor-frame')[index];
-					frame.parentNode.removeChild(frame);
+						let frame = doc.getElementsByClassName('ft-monitor-frame')[index];
+						frame && frame.parentNode.removeChild(frame);
+					}
 				});
 
 				// add note


### PR DESCRIPTION
<!-- Please review the contributing guidelines before submitting this PR. -->
Fixes FT error when you continue to click the Remove button after removing all of the teams from MyMonitor.