### PR TITLE
[players.js] Fix currentLeagueId computation

### DIFF
--- a/content/pages/players.js
+++ b/content/pages/players.js
@@ -1588,7 +1588,7 @@ Foxtrick.Pages.Players.getPlayerList = function(doc, callback, options) {
 							// README: this will break with localized league names
 							let id = parseInt(j, 10);
 							let league = Foxtrick.L10n.getCountryNameNative(id);
-							if (leagueText.indexOf(league) >= -1) {
+							if (leagueText.indexOf(league) > -1) {
 								player.currentLeagueId = id;
 								break;
 							}


### PR DESCRIPTION
Before this PR, all currentLeagueIds were set to the first entry of Foxtrick.XMLData.League (aka id=1, Sweden).

This information is notably used in team-stats, for https://www.hattrick.org/goto.ashx?path=/Club/Players/Oldies.aspx and https://www.hattrick.org/goto.ashx?path=/Club/Players/Coaches.aspx

This change comes with a(n untested) performance hit, since the outer loop now has to be executed rather than directly return on the first iteration.
