### PR TITLE
Restore various modules for NT players page

### DIFF
--- a/content/core.js
+++ b/content/core.js
@@ -68,7 +68,7 @@ Foxtrick.modules.Core = {
 		}
 
 		CORE.parseSelfTeamInfo(doc);
-		if (Foxtrick.isPage(doc, 'allPlayers') || Foxtrick.isPage(doc, 'youthPlayers'))
+		if (Foxtrick.isPage(doc, 'allPlayers') || Foxtrick.isPage(doc, 'youthPlayers') || Foxtrick.isPage(doc, 'ntPlayers'))
 			CORE.parsePlayerList(doc);
 
 		CORE.updateLastPage(doc);

--- a/content/information-aggregation/extra-player-info.js
+++ b/content/information-aggregation/extra-player-info.js
@@ -8,7 +8,7 @@
 
 Foxtrick.modules['ExtraPlayerInfo'] = {
 	MODULE_CATEGORY: Foxtrick.moduleCategories.INFORMATION_AGGREGATION,
-	PAGES: ['allPlayers'],
+	PAGES: ['allPlayers', 'ntPlayers'],
 	OPTIONS: ['CoachInfo', 'Flag', 'Language'],
 
 	addCoachWrapper: function(playerNode, { skill, type }) {

--- a/content/information-aggregation/player-birthday.js
+++ b/content/information-aggregation/player-birthday.js
@@ -8,7 +8,7 @@
 
 Foxtrick.modules.PlayerBirthday = {
 	MODULE_CATEGORY: Foxtrick.moduleCategories.INFORMATION_AGGREGATION,
-	PAGES: ['allPlayers', 'youthPlayers'],
+	PAGES: ['allPlayers', 'youthPlayers', 'ntPlayers'],
 
 	/** @param {document} doc */
 	run: function(doc) {

--- a/content/information-aggregation/skill-table.js
+++ b/content/information-aggregation/skill-table.js
@@ -9,7 +9,7 @@
 
 Foxtrick.modules.SkillTable = {
 	MODULE_CATEGORY: Foxtrick.moduleCategories.INFORMATION_AGGREGATION,
-	PAGES: ['allPlayers', 'youthPlayers', 'transferSearchResult'],
+	PAGES: ['allPlayers', 'youthPlayers', 'transferSearchResult', 'ntPlayers'],
 	OPTIONS: ['FrozenColumns', 'OtherTeams', 'ColouredYouth', 'FullNames'],
 	CSS: Foxtrick.InternalPath + 'resources/css/skilltable.css',
 

--- a/content/information-aggregation/team-stats.js
+++ b/content/information-aggregation/team-stats.js
@@ -8,7 +8,7 @@
 
 Foxtrick.modules.TeamStats = {
 	MODULE_CATEGORY: Foxtrick.moduleCategories.INFORMATION_AGGREGATION,
-	PAGES: ['allPlayers', 'youthPlayers'],
+	PAGES: ['allPlayers', 'youthPlayers', 'ntPlayers'],
 	OPTIONS: [
 		'General', 'Attributes', 'Skills', 'Match', 'Specialty',
 		'Personality', 'Status', 'Current_league',

--- a/content/information-aggregation/u21-lastmatch.js
+++ b/content/information-aggregation/u21-lastmatch.js
@@ -13,7 +13,7 @@ Foxtrick.modules.U21LastMatch = {
 	PAGES: [
 		'youthPlayerDetails', 'playerDetails',
 		'allPlayers', 'youthPlayers',
-		'transferSearchResult',
+		'transferSearchResult', 'ntPlayers'
 	],
 	OPTIONS: ['YouthPlayers', 'SeniorPlayers', 'AllPlayers'],
 	DATE_CUTOFFS: [

--- a/content/links/links-players.js
+++ b/content/links/links-players.js
@@ -7,7 +7,7 @@
 
 Foxtrick.modules['LinksPlayers'] = {
 	MODULE_CATEGORY: Foxtrick.moduleCategories.LINKS,
-	PAGES: ['allPlayers'],
+	PAGES: ['allPlayers', 'ntPlayers'],
 	LINK_TYPES: 'playerslink',
 	/**
 	 * return HTML for FT prefs

--- a/content/presentation/original-face.js
+++ b/content/presentation/original-face.js
@@ -8,7 +8,7 @@
 
 Foxtrick.modules['OriginalFace'] = {
 	MODULE_CATEGORY: Foxtrick.moduleCategories.PRESENTATION,
-	PAGES: ['playerDetails', 'allPlayers', 'youthPlayerDetails', 'youthPlayers'],
+	PAGES: ['playerDetails', 'allPlayers', 'youthPlayerDetails', 'youthPlayers', 'ntPlayers'],
 	OPTIONS: ['HideTransfer', 'HideInjury', 'HideSuspended', 'ColouredYouth'],
 	OPTIONS_CSS: [
 		Foxtrick.InternalPath + 'resources/css/HideFaceTransferImages.css',

--- a/content/presentation/team-select-box.js
+++ b/content/presentation/team-select-box.js
@@ -11,7 +11,7 @@
 
 Foxtrick.modules['TeamSelectBox'] = {
 	MODULE_CATEGORY: Foxtrick.moduleCategories.PRESENTATION,
-	PAGES: ['allPlayers', 'youthPlayers'],
+	PAGES: ['allPlayers', 'youthPlayers', 'ntPlayers'],
 
 	OPTIONS: ['RememberState'],
 

--- a/content/shortcuts-and-tweaks/player-filters.js
+++ b/content/shortcuts-and-tweaks/player-filters.js
@@ -8,7 +8,7 @@
 
 Foxtrick.modules['PlayerFilters'] = {
 	MODULE_CATEGORY: Foxtrick.moduleCategories.SHORTCUTS_AND_TWEAKS,
-	PAGES: ['allPlayers', 'youthPlayers'],
+	PAGES: ['allPlayers', 'youthPlayers', 'ntPlayers'],
 
 	FILTER_SELECT_ID: 'foxtrick-filter-select',
 


### PR DESCRIPTION
This was lost from b13ce1878d2a55c452945886d173ac309aa9ed11.

There might be other features that were disabled from that change, I don't know which ones should be re-enabled in the same way.
Other modules that reference allPlayers: LinksPlayers, OriginalFace, U21LastMatch, PlayerFilters, TeamStats, PlayerBirthday, TeamSelectBox, ExtraPlayerInfo, and also core.js.