### PR TITLE
move nt/u21 players page back to allPlayers page category

### DIFF
--- a/content/pages.js
+++ b/content/pages.js
@@ -98,6 +98,7 @@ Foxtrick.htPages = {
 	'allPlayers'                : '/Club/Players/(Default.aspx|?|$)|' +
 	                              '/Club/Players/(Default.Classic.aspx|?|$)|' +
 	                              '/Club/Players/KeyPlayers(.|.Classic.)aspx|' +
+	                              '/Club/NationalTeam/NTPlayers(.|.Classic.)aspx|' +
 	                              '/Club/Players/Oldies(.|.Classic.)aspx|' +
 	                              '/Club/Players/Coaches(.|.Classic.)aspx',
 
@@ -154,8 +155,7 @@ Foxtrick.htPages = {
 	'newsLetter'                : '/Community/Federations/SendMessage.aspx',
 	'mailNewsLetter'            : '/MyHattrick/Inbox/(Default.aspx?|?)actionType=newsLetter',
 	'ntNewsLetter'              : '/Club/NationalTeam/NTNotice.aspx',
-	'national'                  : '/Club/NationalTeam/NationalTeam.aspx|' +
-	                              '/Club/NationalTeam/NTPlayers(.|.Classic.)aspx',
+	'national'                  : '/Club/NationalTeam/NationalTeam.aspx',
 	'guestbook'                 : '/Club/Manager/Guestbook.aspx',
 	'announcementsView'         : '/Club/Announcements/(Default.aspx?|?)',
 	'announcementsWrite'        : '/Club/Announcements/(New|Edit).aspx',

--- a/res/links.json
+++ b/res/links.json
@@ -341,23 +341,7 @@
 		},
 		"trackerplayerlink": {
 			"url": "https://hattrickportal.online/Tracker/Player.aspx?playerID=[playerid]"
-		},
-		"allow": [
-			"OR",
-			[
-				"EQUAL",
-				"ownteamid",
-				"teamid"
-			],
-			[
-				"EXISTS",
-				"leagueid"
-			],
-			[
-				"EXISTS",
-				"playerid"
-			]
-		]
+		}
 	},
 	"hattrick-youthclub": {
 		"youthlink": {


### PR DESCRIPTION
Reverts changes made by pr #17

Restores skill table, team stats, birthdays etc to NT/U21 Players pages.

Closes #145 

<!-- Please review the contributing guidelines before submitting this PR. -->
