### PR TITLE
[YouthSkills] Remove specialty being displayed twice in playerdetails legacy

### DIFF
--- a/content/information-aggregation/youth-skills.js
+++ b/content/information-aggregation/youth-skills.js
@@ -682,7 +682,7 @@ Foxtrick.modules['YouthSkills'] = {
 					if (isLegacy) {
 						if (isPlayerDetails) {
 							// skip if specialty known on HT
-							if (specContainer.querySelector('p'))
+							if (specContainer.querySelector('p') || specContainer.querySelector('strong'))
 								continue;
 
 							const info = doc.createElement('p');


### PR DESCRIPTION
Fixing
<img width="833" height="221" alt="image" src="https://github.com/user-attachments/assets/2a3772d5-5a2f-4594-9b36-6a19df8a1cde" />
