### PR TITLE
Change Rate My Academy to Scoutrick

### DIFF
--- a/res/links.json
+++ b/res/links.json
@@ -497,17 +497,17 @@
 		"title": "Hattid (AlltidLike)",
 		"img": "https://www.foxtrick.org/res/linkicons/hattid.png"
 	},
-	"ratemyacademy": {
+	"scoutrick": {
 		"youthlink": {
-			"url": "https://www.rate-my.academy/"
+			"url": "https://www.scoutrick.org/"
 		},
 		"youthplayerlistlink": {
-			"url": "https://www.rate-my.academy/"
+			"url": "https://www.scoutrick.org/"
 		},
 		"youthplayerdetaillink": {
-			"url": "https://www.rate-my.academy/"
+			"url": "https://www.scoutrick.org/"
 		},
-		"title": "Rate My Academy",
+		"title": "Scoutrick",
 		"img": "https://www.foxtrick.org/res/linkicons/ratemyacademy.ico"
 	}
 }


### PR DESCRIPTION
Changed references of "Rate My Academy" to "Scoutrick" due to application rebranding. More info on HT forums: 17667022.1. Application icon remains the same.

