### PR TITLE
Update Rate My Academy links to Scoutrick

### DIFF
--- a/res/links.json
+++ b/res/links.json
@@ -426,17 +426,17 @@
 		"title": "Hattid",
 		"img": "https://foxtrick-ng.github.io/foxtrick/linkicons/hattid.png"
 	},
-	"ratemyacademy": {
+	"scoutrick": {
 		"youthlink": {
-			"url": "https://www.rate-my.academy/"
+			"url": "https://www.scoutrick.org/"
 		},
 		"youthplayerlistlink": {
-			"url": "https://www.rate-my.academy/"
+			"url": "https://www.scoutrick.org/"
 		},
 		"youthplayerdetaillink": {
-			"url": "https://www.rate-my.academy/"
+			"url": "https://www.scoutrick.org/"
 		},
-		"title": "Rate My Academy",
+		"title": "Scoutrick",
 		"img": "https://foxtrick-ng.github.io/foxtrick/linkicons/ratemyacademy.ico"
 	},
 	"hattrickorganizer": {


### PR DESCRIPTION
Rate My Academy has been rebranded to Scoutrick. Changed the links to reflect that change. Detailed info on HT forums: [post=17667022.1]
