### PR TITLE
update chpp docs url

### DIFF
--- a/content/pages.js
+++ b/content/pages.js
@@ -206,7 +206,7 @@ Foxtrick.pagesExcluded = {
 	'oath'                      : 'chpp.hattrick.org/',
 	'error'                     : '/Errors/',
 	'logout'                    : '/Logout.aspx',
-	'chppExampleApp'            : '/Community/CHPP/NewDocs/Example.aspx',
+	'chppExampleApp'            : '/Community/CHPP/NewDocs/',
 };
 
 /* eslint-enable key-spacing, quote-props */


### PR DESCRIPTION
Foxtrick is supposed to be disabled on the CHPP api docs page, but the url  match in pages.js was incorrect.
