### PR TITLE
Fix CopyPlayerAd - split-attributes false-positives

### DIFF
--- a/content/shortcuts-and-tweaks/copy-player-ad.js
+++ b/content/shortcuts-and-tweaks/copy-player-ad.js
@@ -220,10 +220,10 @@ Foxtrick.modules.CopyPlayerAd = {
 			{
 				name: 'split-attributes',
 				playerType: 'senior',
-				regex: '^.+\\..+\\..+\\.',
+				regex: '^[^\\d]+?\\.[^\\d]+?\\.[^\\d]+?\\.',
 				type: 'replace',
 				exec: (str) => {
-					const match = str.match('^(.+\\.)\\s?(.+\\..+\\.)');
+					const match = str.match('^(.+?\\.)\\s?(.+?\\..+?\\.)');
 					if (match?.length == 3)
 						return `${match[1]}[br]${match[2]}`;
 				},


### PR DESCRIPTION
closes #254 - lines with period as a date separator are split

<!-- Please review the contributing guidelines before submitting this PR. -->
