### PR TITLE
Fix chrome incorrectly showing permissions needed note

### DIFF
--- a/background/worker.js
+++ b/background/worker.js
@@ -75,7 +75,18 @@ chrome.runtime.onMessage.addListener((msg, sender, responseCallback) => {
 			return true;
 
 		case 'containsPermission':
-			chrome.permissions.contains(msg.types, responseCallback);
+			try {
+				chrome.permissions.contains(msg.types)
+					.then(function(result) {
+						responseCallback(result);
+					})
+					.catch(function(err) {
+						responseCallback({ __permError: String(err) });
+					});
+			}
+			catch (e) {
+				responseCallback({ __permError: String(e) });
+			}
 			return true;
 	}
 	return false;

--- a/content/prefs-util.js
+++ b/content/prefs-util.js
@@ -542,7 +542,9 @@ Foxtrick.Prefs.getNeededPermissions = function() {
 			}
 
 			Foxtrick.containsPermission(item.types, function(granted) {
-				if (granted) {
+				// treat undefined as granted: works around MV3 service worker
+				// message channel issues where responseCallback is never called
+				if (granted !== false) {
 					resolve(null);
 					return;
 				}

--- a/content/shortcuts-and-tweaks/copy-youth.js
+++ b/content/shortcuts-and-tweaks/copy-youth.js
@@ -9,15 +9,15 @@
 Foxtrick.modules.CopyYouth = {
 	MODULE_CATEGORY: Foxtrick.moduleCategories.SHORTCUTS_AND_TWEAKS,
 	PAGES: ['youthTraining', 'youthPlayerDetails', 'youthOverview'],
-	// 'AutoSendRejectedToHY' temporarily removed from OPTIONS to
-	// hide option in prefs until feature is fixed
+	// 'AutoSendRejectedToHY' temporarily removed from OPTIONS
+	// and PERMISSIONS to hide option until feature is fixed
 	OPTIONS: [
 		'TrainingReport', 'AutoSendTrainingReportToHY', 'ScoutComment',
 		'AutoSendTrainingChangesToHY',
 	],
 	PERMISSIONS: {
 		AutoSendTrainingReportToHY: { origins: ['https://*.hattrick-youthclub.org/*'] },
-		AutoSendRejectedToHY: { origins: ['https://*.hattrick-youthclub.org/*'] },
+		// AutoSendRejectedToHY: { origins: ['https://*.hattrick-youthclub.org/*'] },
 		AutoSendTrainingChangesToHY: { origins: ['https://*.hattrick-youthclub.org/*'] },
 	},
 

--- a/content/util/permissions.js
+++ b/content/util/permissions.js
@@ -14,8 +14,17 @@ if (!this.Foxtrick)
 
 Foxtrick.containsPermission = function(types, callback) {
 	if (Foxtrick.platform == 'Chrome') {
-		if (Foxtrick.context == 'content')
-			Foxtrick.SB.ext.sendRequest({ req: 'containsPermission', types: types }, callback);
+		if (Foxtrick.context == 'content') {
+			Foxtrick.SB.ext.sendRequest({ req: 'containsPermission', types: types }, function(response) {
+				if (response && response.__permError) {
+					Foxtrick.log(new Error('containsPermission: ' + response.__permError));
+					callback(undefined);
+				}
+				else {
+					callback(response);
+				}
+			});
+		}
 		else
 			chrome.permissions.contains(types, callback);
 


### PR DESCRIPTION
[HT forum post](https://www.hattrick.org/goto.ashx?path=%2FForum%2FRead.aspx%3Ft%3D17671567%26n%3D4)

> There are enabled Foxtrick options that require additional browser permissions. Click OK to open Foxtrick preferences, then click Save to request permissions.<br><br>Every time I click OK, it takes me to the foxtrick page. I click Save, but this message always remains.<br><br><br>edit.<br><br>Solved. The error disappears after uninstalling and reinstalling.<br><br>

Basically what is happening is that Foxtrick is incorrectly determining that there are additional browser permissions needed. (granted == undefined in Foxtrick.Prefs.getNeededPermissions)  This only happens in chrome for users who have updated from versions prior to the permissions changes in 0.19.7.0, and even then it seems sensitive to other unknown conditions - i.e. not everyone sees this issue.

This PR effectively suppresses the problem rather than fixes it.  That should be okay, given that it only happens to users who have already granted all permissions.  This issue won't happen once we move away from the whole 'load unpacked' way of doing things, so I don't want to spend endless amounts of time diagnosing exactly why this edge case occurs.
