### PR TITLE
Fix typo in personalized link - es-CR locale

### DIFF
--- a/content/locale/es-CR/foxtrick.properties
+++ b/content/locale/es-CR/foxtrick.properties
@@ -1428,7 +1428,7 @@ ConfirmActions.ntremove=¿Deseas añadir/remover este jugador del equipo?
 # links
 links.boxheader=Enlaces
 links.custom.selecticon=Seleccionar icono
-links.custom.addpersonallink=Añadir enlace persinalizado
+links.custom.addpersonallink=Añadir enlace personalizado
 links.custom.addlink=Añadir enlace
 links.custom.remove=Eliminar
 links.custom.copy=Copiar


### PR DESCRIPTION
Simple typo in es-CR text for the link box.
From "Añadir enlace persinalizado" to  "Añadir enlace personalizado" 
Should fix #311 
