### PR TITLE
Fix typo in personalized link - es-AR locale

### DIFF
--- a/content/locale/es-AR/foxtrick.properties
+++ b/content/locale/es-AR/foxtrick.properties
@@ -1463,7 +1463,7 @@ ConfirmActions.ntremove=¿Deseas añadir/remover este jugador del equipo?
 # links
 links.boxheader=Enlaces
 links.custom.selecticon=Seleccionar icono
-links.custom.addpersonallink=Añadir enlace persinalizado
+links.custom.addpersonallink=Añadir enlace personalizado
 links.custom.addlink=Añadir enlace
 links.custom.remove=Eliminar
 links.custom.copy=Copiar


### PR DESCRIPTION
Simple typo in es-AR text for the link box.
From "Añadir enlace persinalizado" to  "Añadir enlace personalizado" 
Should fix #311 
