### PR TITLE
fix: correct persinalizado → personalizado in es-AR and es-CR locales

### DIFF
--- a/content/locale/es-AR/foxtrick.properties
+++ b/content/locale/es-AR/foxtrick.properties
@@ -1463,7 +1463,7 @@ ConfirmActions.ntremove=¿Deseas añadir/remover este jugador del equipo?
 # links
 links.boxheader=Enlaces
 links.custom.selecticon=Seleccionar icono
-links.custom.addpersonallink=Añadir enlace persinalizado
+links.custom.addpersonallink=Añadir enlace personalizado
 links.custom.addlink=Añadir enlace
 links.custom.remove=Eliminar
 links.custom.copy=Copiar

--- a/content/locale/es-CR/foxtrick.properties
+++ b/content/locale/es-CR/foxtrick.properties
@@ -1428,7 +1428,7 @@ ConfirmActions.ntremove=¿Deseas añadir/remover este jugador del equipo?
 # links
 links.boxheader=Enlaces
 links.custom.selecticon=Seleccionar icono
-links.custom.addpersonallink=Añadir enlace persinalizado
+links.custom.addpersonallink=Añadir enlace personalizado
 links.custom.addlink=Añadir enlace
 links.custom.remove=Eliminar
 links.custom.copy=Copiar


### PR DESCRIPTION
## Summary
Corrects a typo in the Spanish (Argentina) and Spanish (Costa Rica) locale files:
- `es-AR/foxtrick.properties:1466`: `Añadir enlace persinalizado` → `Añadir enlace personalizado`
- `es-CR/foxtrick.properties:1431`: `Añadir enlace persinalizado` → `Añadir enlace personalizado`

## Fixes
Fixes #309, #310, #311

## Testing
Verified the typo was present in both locale files and corrected in both.